### PR TITLE
Add tools (cfr, linux-inject) and remove NCTU wargame system

### DIFF
--- a/data.json
+++ b/data.json
@@ -528,13 +528,6 @@
 				"difficulty": 3
 			},
 			{
-				"name": "NCTU Online Judge",
-				"url": "http://wargame.cs.nctu.edu.tw/",
-				"description": "交大 Wargame Online Judge",
-				"category": ["complex"],
-				"difficulty": 5
-			},
-			{
 				"name": "Hack This Site (HTS)",
 				"url": "https://www.hackthissite.org/",
 				"description": "較接近實戰練習的線上 Wargame",

--- a/data.json
+++ b/data.json
@@ -503,6 +503,13 @@
 				"description": "支援 Java8 lambdas / Java7 switch on strings 等新語法的 Java decompiler",
 				"category": ["reversing"],
 				"difficulty": 2
+			},
+			{
+				"name": "linux-inject",
+				"url": "https://github.com/gaffe23/linux-inject",
+				"description": "Linux 的 ELF 注入工具 (就像 Windows 的 DLL injection)",
+				"category": ["reversing"],
+				"difficulty": 2
 			}
 		],
 		"遊戲/練功房": [

--- a/data.json
+++ b/data.json
@@ -496,6 +496,13 @@
 				"description": "一些好用而強大的 Honeypots 整理",
 				"category": ["complex"],
 				"difficulty": 3
+			},
+			{
+				"name": "CFR -- another java decompiler",
+				"url": "http://www.benf.org/other/cfr/",
+				"description": "支援 Java8 lambdas / Java7 switch on strings 等新語法的 Java decompiler",
+				"category": ["reversing"],
+				"difficulty": 2
 			}
 		],
 		"遊戲/練功房": [


### PR DESCRIPTION
- cfr: java decompiler，支援新版java語法
- linux-inject: ELF 注入工具，相當於 Windows 上的 DLL 注入
- 交大舊的 wargame 系統關了，現在應該是 Bamboofox 的 CTF 平台
