### PR TITLE
Fix the link of "技术入门游戏安全实验室"

### DIFF
--- a/data.json
+++ b/data.json
@@ -66,7 +66,7 @@
 			},
 			{
 				"name": "技术入门游戏安全实验室",
-				"url": "http://gslab.qq.com/jc/",
+				"url": "http://gslab.qq.com/js/",
 				"description": "對手機遊戲的資安入門介紹",
 				"category": ["reversing", "mobile"],
 				"difficulty": 5


### PR DESCRIPTION
The original link is not working now. Change it to http://gslab.qq.com/js/ .